### PR TITLE
Add ble-scale-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 #### Libraries and Tools
 
+ - [ble-scale-sync](https://github.com/KristianP26/ble-scale-sync) - Cross-platform Node.js CLI that reads BLE smart scales (23 brands), calculates body composition, and exports to Garmin Connect, MQTT, InfluxDB, Webhook, and Ntfy. Runs on Raspberry Pi, Linux, macOS, and Windows.
  - [Cylon.js](http://cylonjs.com/) - Cylon.js is a JavaScript framework for robotics, physical computing, and the Internet of Things. It makes it incredibly easy to command robots and devices.
  - [Luvit](https://luvit.io/) - Luvit implements the same APIs as Node.js, but in Lua! While this framework is not directly involved with IoT development, it is still a *great* way to rapidly build powerful, yet memory efficient, embedded web applications.
  - [Johnny-Five](http://johnny-five.io/) - Johnny-Five is the original JavaScript Robotics programming framework. Released by Bocoup in 2012, Johnny-Five is maintained by a community of passionate software developers and hardware engineers.


### PR DESCRIPTION
Adds [ble-scale-sync](https://github.com/KristianP26/ble-scale-sync) to the Libraries and Tools section.

A cross-platform Node.js CLI that reads BLE smart scales (23 brands), calculates body composition metrics, and exports to Garmin Connect, MQTT, InfluxDB, Webhook, and Ntfy. Designed for Raspberry Pi but also runs on Linux, macOS, and Windows.