### PR TITLE
Add PiSpot-Show to Miscellaneous section

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
  - [Gladys](https://gladysassistant.com) - Gladys is an open-source program that runs on the Raspberry Pi and integrates into the entire home network system.
  - [authBroker](https://github.com/authbroker/authbroker) - A Keycloak HTTP/MQTT/CoAP IoT Brokers Adapter like Aedes.
  - [MQTT File Uploader](https://github.com/volkanalkilic/Mqtt-File-Uploader) - MQTT File Uploader is a simple Cross-platform .NET Core application that watches local directories for changes and uploads new or modified files to an MQTT broker.
+ - [PiSpot-Show](https://github.com/GeiserX/PiSpot-Show) - A Raspberry Pi captive portal that creates a WiFi hotspot displaying a customizable web page to connected users using hostapd, dnsmasq, and nginx. Useful for events, marketing, and education.
 - [SIGNL4 – Mobile Alerting](https://www.signl4.com/iot-service-alerting/) - SIGNL4 brings reliable mobile alerting with app push, SMS, and voice calls – plus escalation and duty scheduling – for your IoT projects.
 
 ## Protocols and Networks


### PR DESCRIPTION
## Summary

- Adds [PiSpot-Show](https://github.com/GeiserX/PiSpot-Show) to the **Software > Miscellaneous** section.
- PiSpot-Show is a Raspberry Pi captive portal that creates a WiFi hotspot displaying a customizable web page to connected users using hostapd, dnsmasq, and nginx.
- Licensed under MIT. Useful for events, marketing, and education scenarios.

Generated with [Claude Code](https://claude.com/claude-code)