### PR TITLE
Add Rinho Telematics GPS trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 - [Tessel](https://tessel.io/) - Tessel is a completely open source and community-driven IoT and robotics development platform. It encompasses development boards, hardware module add-ons, and the software that runs on them.
 - [UDOO](http://www.udoo.org) - UDOO is a single-board computer with an integrated Arduino 2 compatible microcontroller, designed for computer science education, the world of Makers and the Internet of Things.
 - [Raspberry Pi Pico](https://www.raspberrypi.com/products/raspberry-pi-pico/) - Raspberry Pi Pico is a small, fast and versatile board that is equipped with the RP2040 microcontroller chip developed by the Raspberry Pi Foundation. It also comes with a 2.4GHz 802.11n wireless LAN variant, which makes it great for IoT.
+- [Rinho Telematics](https://rinho.com.ar/en) - GPS trackers with native CAN Bus (J1939/FMS), WiFi fallback for offline data download, and BLE 5.0 sensors. Compatible with Traccar and Wialon.
 - [WisBlock](https://www.rakwireless.com/en-us/products/wisblock) - WisBlock is a modular system that makes it easy to implement low power wide area network (LPWAN) into IoT solutions. WisBlock consists of a base board, core compute module and combination of several sensor modules.
 
 ### Software


### PR DESCRIPTION
## Description
Adding Rinho Telematics to the Hardware section.

Rinho is an Argentine GPS tracker manufacturer with relevant IoT features:

- **Native CAN Bus**: Reads J1939/FMS without external adapters
- **WiFi Fallback**: Downloads data in areas without cellular coverage
- **BLE 5.0**: Connects temperature sensors, TPMS, iButton readers
- **Open Protocol**: Works with Traccar, Wialon, and custom platforms
- **ESP32 processor**

Website: https://rinho.com.ar/en

This fits the Hardware section alongside similar IoT devices like AutoPi, ESP32, and WisBlock.