### PR TITLE
Add Electrum to Software > Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
  - [Amazon Dash](https://fresh.amazon.com/dash/) - Amazon Dash Button is a Wi-Fi connected device that reorders your favorite item with the press of a button.
  - [BirdNET-Go](https://github.com/tphakala/birdnet-go) - Realtime wildlife soundscape analyser with multi-model AI inference, MQTT publishing with Home Assistant discovery, and web dashboard.
+ - [Electrum](https://github.com/yoelf22/electrum) - A structured, AI-assisted toolkit for defining hardware products that have software inside — from concept through engineering spec to presentation-ready materials in eight phases.
  - [Freeboard](http://freeboard.io/) - A real-time interactive dashboard and visualization creator implementing an intuitive drag & drop interface.
  - [Nebula](http://nebula.readthedocs.io) -  A docker orchestrator designed to manage IoT devices.
  - [Gladys](https://gladysassistant.com) - Gladys is an open-source program that runs on the Raspberry Pi and integrates into the entire home network system.


### PR DESCRIPTION
Adding **Electrum** to the `Software > Miscellaneous` section.

Electrum is an MIT-licensed Python toolkit and Claude Code skill for the product-definition phase of hardware products that contain embedded software — it walks an idea through HW/SW boundary mapping, a full engineering system description, a 90-item gate checklist, and a LinkedIn-format PPTX/PDF carousel. Markdown templates also work without AI.

It fits this section because it's a methodology/template toolkit rather than a runtime library, framework, or middleware. Miscellaneous already houses similarly odd-shaped entries (Freeboard, Nebula, Gladys, Amazon Dash).

Per `CONTRIBUTING.md`:

- Submitted from branch `add-electrum`, not `master`. ✔
- Format: `[Name](url) - Description.` (capitalized, period-terminated). ✔
- Sub-list alphabetical position respected (between BirdNET-Go and Freeboard). ✔
- Description taken from the project's GitHub description verbatim. ✔
- No trailing whitespace. ✔

Repo: https://github.com/yoelf22/electrum (MIT, v0.1.0 release, 7 worked examples).