### PR TITLE
Add aem-modbus-simulator to Libraries and Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 #### Libraries and Tools
 
+ - [aem-modbus-simulator](https://github.com/leaberg69/aem-modbus-simulator) - Open-source Python Modbus RTU/TCP slave simulator emulating the LRI AEM-60DC8 industrial DC monitor. Mirrors 147 holding registers, 8 DC channels, six baudrates (4,800-115,200). Useful for SCADA/PLC integration testing without physical hardware.
  - [ble-scale-sync](https://github.com/KristianP26/ble-scale-sync) - Cross-platform Node.js CLI that reads BLE smart scales (23 brands), calculates body composition, and exports to Garmin Connect, MQTT, InfluxDB, Webhook, and Ntfy. Runs on Raspberry Pi, Linux, macOS, and Windows.
  - [Cylon.js](http://cylonjs.com/) - Cylon.js is a JavaScript framework for robotics, physical computing, and the Internet of Things. It makes it incredibly easy to command robots and devices.
  - [Luvit](https://luvit.io/) - Luvit implements the same APIs as Node.js, but in Lua! While this framework is not directly involved with IoT development, it is still a *great* way to rapidly build powerful, yet memory efficient, embedded web applications.


### PR DESCRIPTION
## Summary

Adds [aem-modbus-simulator](https://github.com/leaberg69/aem-modbus-simulator) to the **Libraries and Tools** section in alphabetical order (first entry, starts with "a").

### What it is

Open-source Python Modbus RTU/TCP slave simulator emulating the LRI AEM-60DC8 industrial DC voltage monitor. Mirrors 147 holding registers in 17 functional blocks, supports six baudrates (4,800-115,200 bps), TCP and Serial modes. Useful for:

- SCADA / HMI / PLC integration testing without physical hardware
- CI pipelines for industrial automation projects
- Engineering training and educational labs
- Pre-deployment validation before site commissioning

### Why it fits this section

The section already includes other simulators and tools (MIMIC IoT Simulator, MQTT Explorer, MQTT X). The Modbus simulator complements them for industrial OT side of IoT (legacy RS-485 / Modbus stacks that are still very widely deployed).

### Disclosure

I work at LRI Automação Industrial (the manufacturer of the hardware being simulated). The simulator itself is fully open-source under MIT license and the Modbus register map is a public interface anyway.